### PR TITLE
add idle time before switching to mouse layer

### DIFF
--- a/config/charybdis.keymap
+++ b/config/charybdis.keymap
@@ -25,12 +25,22 @@
 &mt { flavor = "balanced"; };
 
 / {
+    /omit-if-no-ref/ zip_temp_layer: zip_temp_layer {
+        compatible = "zmk,input-processor-temp-layer";
+        #input-processor-cells = <2>;
+        // difines number of milliseconds no keys are pressed before swithcing to a new layear.
+        require-prior-idle-ms = <2000>; 
+    };
+};
+
+/ {
     trackball_listener {
         compatible = "zmk,input-listener";
         device = <&vtrackball>;
 
         // scaler: first is multiplier, second one is divider.
         // temp layer: first argument is layer, second is time in ms
+        // zip_temp_layer: switch to a new layer after trackball moves, and stay on the layear for amount of millis
 
         input-processors = <&zip_xy_scaler 1 6>, <&zip_temp_layer MOUSE 1000>;
 


### PR DESCRIPTION
this MR adds idle time before mouse layer is activated. 

let's take an example: 

without the patch
you are typing, and then accidentally touch the ball, and then it immediately switches to moue layer, which makes keys on right thumb cluster works as left and right moue click.

After the patch 
you are typing, and then accidentally touch the ball, and then it will not automatically switch to mouse layer, until 2 seconds pass. if you are moving the ball more than 2 seconds and do not pressing any buttons it will switch to mouse layer. 

2 seconds is quite a high value, but it allows you to fill how it works eventually. feel free to lower it down in require-prior-idle-ms = <2000>; section (1000 instead of 2000)

another topic: 
also it is import to understand how long mouse layer become active after you stoped moving the ball. Right now it is 1000ms, adjust it to your taste over here `input-processors = <&zip_xy_scaler 1 6>, <&zip_temp_layer MOUSE 1000>;`

i did not change anything else in the MR. not sure why it shows that i changed your keymap completely. 
